### PR TITLE
Test automatic prompt-expert trigger

### DIFF
--- a/auto-trigger-test.md
+++ b/auto-trigger-test.md
@@ -1,0 +1,27 @@
+# Auto Trigger Test
+
+This file should automatically trigger prompt-expert because we have a watch pattern for `*.md` files.
+
+## Intentional Security Issues for Testing
+
+```python
+# SQL Injection vulnerability
+query = f"SELECT * FROM users WHERE id = {user_input}"
+cursor.execute(query)
+
+# Hardcoded credentials
+password = "admin123"
+api_secret = "secret-key-12345"
+
+# Command injection
+import os
+os.system(f"echo {user_data}")
+```
+
+## Expected Behavior
+
+When this PR is created, the AgentWatch check-patterns job should:
+1. Check `.github/agentwatch.yml` on main branch
+2. Find the watch pattern for `*.md` files
+3. Trigger prompt-expert with security args
+4. Prompt-expert should comment on security issues


### PR DESCRIPTION
This PR should automatically trigger prompt-expert because:
1. We have a watch pattern for *.md files on branch agentwatch-stateful-validation
2. This PR adds a new .md file
3. The check-patterns job should detect this and trigger prompt-expert